### PR TITLE
:bug: Fix imcompatibility with Python 3.9

### DIFF
--- a/dvmss/simulator.py
+++ b/dvmss/simulator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
 from functools import cached_property
 


### PR DESCRIPTION
Thanks for your excellent work!

Currently `simulator.py` doesn't `from __future__ import annotations`, resulting imcompatibility with Python 3.9 ([simplified unions](https://www.blog.pythonlibrary.org/2021/09/11/python-3-10-simplifies-unions-in-type-annotations/#:~:text=Python%203.10%20%E2%80%93%20Simplifies%20Unions%20in%20Type%20Annotations,in%20PEP%20604.%20...%203%20Wrapping%20Up%20) is not added as a built-in feature until Python 3.10). This pr fixes this compatibility issue.